### PR TITLE
[CI, kinetic] Add Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+dist: trusty 
+services:
+  - docker
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    recipients:
+      - gm130s@gmail.com
+env:
+  matrix:
+    - ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu NOT_TEST_BUILD=true NOT_TEST_INSTALL=true
+    - ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu NOT_TEST_BUILD=true NOT_TEST_INSTALL=true
+    - ROS_DISTRO="kinetic"   PRERELEASE=true
+    - ROS_DISTRO="kinetic"  NOT_TEST_BUILD=true NOT_TEST_INSTALL=true
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="kinetic" PRERELEASE=true  # Run docker-based ROS prerelease test http://wiki.ros.org/bloom/Tutorials/PrereleaseTest Because we might not want to run prerelease test for all PRs, it's omitted from pass-fail criteria.
+before_script:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - source .ci_config/travis.sh
+#  - source ./travis.sh  # Enable this when you have a package-local script 


### PR DESCRIPTION
[industrial_ci](https://github.com/ros-industrial/industrial_ci) is a set of CI configs hosted on another repository and it frees you from maintaining CI configs, which itself has nothing to do with robotics. For each run of Travis your jobs fetch the latest config by git clone.

To utilize this @pschillinger needs to activate Travis for this repository. You can do so probably at somewhere like https://travis-ci.org/profile/pschillinger