### PR TITLE
[enhancement] Search .test files in addition to .launch files.

### DIFF
--- a/src/rqt_launchtree/launchtree_widget.py
+++ b/src/rqt_launchtree/launchtree_widget.py
@@ -213,7 +213,7 @@ class LaunchtreeWidget(QWidget):
 	def _is_launch_file(self, path):
 		if not os.path.isfile(path): return False
 		(root, ext) = os.path.splitext(path)
-		if ext != '.launch': return False
+		if ext not in ('.launch', '.test'): return False
 		return True
 
 	def launch_entry_changed(self, current, previous):


### PR DESCRIPTION
Since `*.test` are .launch files too, `rqt_launchtree` is useful for introspecting those files.